### PR TITLE
Pin mode not being set at initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pin = GPIO.new(9, GPIO::OUT)
 The direction of a pin can be changed at any point of the code using the `set_mode` method.
 
 ```ruby
-pin.set_mode(GPIO::IN)
+pin.mode = GPIO::IN
 ```
 
 ### Reading pin's value

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pin.mode = GPIO::IN
 To read the pin value, we're going to use the `get_value` method.
 
 ```ruby
-pin.get_value
+pin.value
 
 # Example output : 0
 ```
@@ -120,11 +120,11 @@ The `LOW` and `HIGH` constants are here to let us set them while keeping code cl
 ```ruby
 # Imagine that a LED is connected to our pin.
 
-pin.set_value(GPIO::HIGH)
+pin.value = GPIO::HIGH
 
 # Output : the LED is on
 
-pin.set_value(GPIO::LOW)
+pin.value = GPIO::LOW
 
 # Output : the LED is off
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This library uses /sys/class/gpio interface to communicate with GPIO pins. It do
   - [Defining a pin](#defining-a-pin)
   - [Reading pin's value](#reading-pins-value)
   - [Outputing a value](#outputing-a-value)
+  - [Cleanup pin](#cleanup-pin)
 - [🔐 License](#-license)
 
 ## 📌 Requirements
@@ -89,7 +90,7 @@ We can use the `OUT` and `IN` constants for the direction.
 pin = GPIO.new(9, GPIO::OUT)
 ```
 
-The direction of a pin can be changed at any point of the code using the `set_mode` method.
+The direction of a pin can be changed at any point of the code using the `mode` property.
 
 ```ruby
 pin.mode = GPIO::IN
@@ -97,7 +98,7 @@ pin.mode = GPIO::IN
 
 ### Reading pin's value
 
-To read the pin value, we're going to use the `get_value` method.
+To read the pin value, we're going to use the `value` property.
 
 ```ruby
 pin.value
@@ -110,7 +111,7 @@ pin.value
 
 ### Outputing a value
 
-To set the value of a pin, the GPIO class has a `set_value` method that can take two values :
+To set the value of a pin, the GPIO class has a `value` property that can take two values :
 
 - 0, no power (low)
 - 1, maximum power (high)
@@ -127,6 +128,15 @@ pin.value = GPIO::HIGH
 pin.value = GPIO::LOW
 
 # Output : the LED is off
+```
+
+### Cleanup pin
+
+It a good practice to unexport the pin once you're done working with it. For
+this, just call a `cleanup` method on the pin's instance:
+
+```ruby
+pin.cleanup
 ```
 
 ## 🔐 License

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ gem build ./raspi-gpio.gemspec
 Finally, install it on your system.
 
 ```bash
-gem install ./raspi-gpio-1.x.x.gem
+gem install ./raspi-gpio-2.x.x.gem
 ```
 
 ## ⌨ Basic interactions
@@ -75,7 +75,7 @@ require 'raspi-gpio'
 
 A GPIO pin is defined with three things :
 
-- a pin number (the number of total pins depend on your Raspberry model)
+- a pin number (the number of total pins depend on your Raspberry model - please, visit the [pinout guide](https://pinout.xyz/))
 - a direction (in or out)
 - a value (low or high)
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,12 @@ The raspi-gpio library has been tested on models : 3B
 
 ## 🔧 Setup
 
-### Quick installation
-
-If you want to quickly test the library, you can install it using the `install` command of Ruby Gem.
-
-```bash
-gem install raspi-gpio
-```
-
 ### Gemfile
 
 If you setup the library for medium or big projects, it's recommended to write it in your Gemfile.
 
 ```gemfile
-gem 'raspi-gpio', '~> 1.0'
+gem 'raspi-gpio', github: 'sergio1990/raspi-gpio-rb'
 ```
 
 After, use again the `install` command, but without the package name.
@@ -52,8 +44,8 @@ gem install
 You can also compile it by yourself. First, clone the repository.
 
 ```bash
-git clone https://github.com/exybore/raspi-gpio-rb.git  # HTTP
-          git@github.com:exybore/raspi-gpio-rb.git      # SSH
+git clone https://github.com/sergio1990/raspi-gpio-rb.git  # HTTP
+          git@github.com:sergio1990/raspi-gpio-rb.git      # SSH
 ```
 
 Then, build the gemspec file to create the gem.
@@ -94,13 +86,13 @@ The `GPIO` class is the way the library provides to register our pins. The initi
 We can use the `OUT` and `IN` constants for the direction.
 
 ```ruby
-pin = GPIO.new(9, OUT)
+pin = GPIO.new(9, GPIO::OUT)
 ```
 
 The direction of a pin can be changed at any point of the code using the `set_mode` method.
 
 ```ruby
-pin.set_mode(IN)
+pin.set_mode(GPIO::IN)
 ```
 
 ### Reading pin's value
@@ -128,11 +120,11 @@ The `LOW` and `HIGH` constants are here to let us set them while keeping code cl
 ```ruby
 # Imagine that a LED is connected to our pin.
 
-pin.set_value(HIGH)
+pin.set_value(GPIO::HIGH)
 
 # Output : the LED is on
 
-pin.set_value(LOW)
+pin.set_value(GPIO::LOW)
 
 # Output : the LED is off
 ```

--- a/examples/common_pwm.rb
+++ b/examples/common_pwm.rb
@@ -1,0 +1,9 @@
+require_relative '../lib/raspi-pwm.rb'
+
+pwm = RaspiPWM.new(channel: 0)
+pwm.frequency = 2
+pwm.duty_cycle = 50
+pwm.enabled = true
+sleep(10)
+pwm.enabled = false
+pwm.cleanup

--- a/examples/common_pwm.rb
+++ b/examples/common_pwm.rb
@@ -1,12 +1,16 @@
 require_relative '../lib/raspi-pwm.rb'
 
+puts 'Initializing PWM #0 channel...'
 pwm = RaspiPWM.new(channel: 0)
 # to give for the system some time for creating
 # needed files and setting appropriate permissions
 sleep(0.5)
+puts 'Setting PWM parameters'
 pwm.frequency = 2
 pwm.duty_cycle = 50
 pwm.enabled = true
+puts 'PWM was enabled! Letting it to run for the next 10 seconds...'
 sleep(10)
-pwm.enabled = false
+puts 'Done'
 pwm.cleanup
+puts 'Everything was cleaned up! Good bye...'

--- a/examples/common_pwm.rb
+++ b/examples/common_pwm.rb
@@ -1,6 +1,9 @@
 require_relative '../lib/raspi-pwm.rb'
 
 pwm = RaspiPWM.new(channel: 0)
+# to give for the system some time for creating
+# needed files and setting appropriate permissions
+sleep(0.5)
 pwm.frequency = 2
 pwm.duty_cycle = 50
 pwm.enabled = true

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -65,14 +65,14 @@ class GPIO
   #
   # @param pin [Integer] GPIO pin number to use
   # @param mode [String] pin mode : IN or OUT
-  def initialize(pin, mode = OUT)
+  def initialize(pin, _mode = OUT)
     @pin = pin
 
     unexport_pin
     export_pin
-
-    @mode = mode
     @exported = true
+
+    self.mode = _mode
   end
 
   # Set the pin mode

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -4,35 +4,37 @@
 #
 # @author exybore
 
-# GPIO core library path
-LIB_PATH = '/sys/class/gpio'
-
-# Shortcut for low pin value (0)
-LOW = 0
-
-# Shortcut for high pin value (1)
-HIGH = 1
-
-# Shortcut for 'in' pin mode
-IN = 'in'
-
-# Shortcut for 'out' pin mode
-OUT = 'out'
-
-# Exception to handle unknown pin mode (not IN or OUT)
-class UnknownMode < StandardError
-end
-
-# Exception to handle pin writing when not in OUT mode
-class NotOutMode < StandardError
-end
-
-# Exception to handle bad pin value (not LOW or HIGH)
-class BadValue < StandardError
-end
-
 # Main class, to manage GPIO pins
 class GPIO
+  # GPIO core library path
+  LIB_PATH = '/sys/class/gpio'
+
+  # Shortcut for low pin value (0)
+  LOW = 0
+
+  # Shortcut for high pin value (1)
+  HIGH = 1
+
+  # Shortcut for 'in' pin mode
+  IN = 'in'
+
+  # Shortcut for 'out' pin mode
+  OUT = 'out'
+
+  class BaseError < StandardError
+  end
+
+  # Exception to handle unknown pin mode (not IN or OUT)
+  class UnknownModeError < BaseError
+  end
+
+  # Exception to handle pin writing when not in OUT mode
+  class NotOutModeError < BaseError
+  end
+
+  # Exception to handle bad pin value (not LOW or HIGH)
+  class BadValueError < BaseError
+  end
 
   # Initialize the GPIO pin
   #
@@ -58,7 +60,7 @@ class GPIO
   # @param mode [String] pin mode : IN or OUT
   # @raise [UnknownMode] if the mode isn't IN or OUT
   def set_mode(mode)
-    raise UnknownMode, "gpio error : unknown mode #{mode}" unless mode == IN or mode == OUT
+    raise UnknownModeError, "gpio error : unknown mode #{mode}" unless mode == IN or mode == OUT
     File.open("#{LIB_PATH}/gpio#{@pin}/direction", 'w') do |file|
       file.write(mode)
     end
@@ -79,8 +81,8 @@ class GPIO
   # @raise [NotOutMode] if the pin isn't in OUT mode
   # @raise [BadValue] if the provided value isn't LOW or HIGH
   def set_value(v)
-    raise NotOutMode, "error : mode isn't OUT" unless @mode == OUT
-    raise BadValue, "error : bad pin value" unless v.between? 0,1
+    raise NotOutModeError, "error : mode isn't OUT" unless @mode == OUT
+    raise BadValueError, "error : bad pin value" unless v.between? 0,1
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'w') do |file|
       file.write(v)
     end

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -36,6 +36,8 @@ class GPIO
   class BadValueError < BaseError
   end
 
+  attr_reader :mode
+
   # Initialize the GPIO pin
   #
   # @param pin [Integer] GPIO pin number to use
@@ -59,12 +61,14 @@ class GPIO
   #
   # @param mode [String] pin mode : IN or OUT
   # @raise [UnknownMode] if the mode isn't IN or OUT
-  def set_mode(mode)
-    raise UnknownModeError, "gpio error : unknown mode #{mode}" unless mode == IN or mode == OUT
+  def mode=(new_mode)
+    raise UnknownModeError, "gpio error : unknown mode #{new_mode}" unless new_mode == IN or new_mode == OUT
+
     File.open("#{LIB_PATH}/gpio#{@pin}/direction", 'w') do |file|
       file.write(mode)
     end
-    @mode = mode
+
+    @mode = new_mode
   end
 
   # Read the value of the pin

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -108,7 +108,7 @@ class GPIO
   def value=(new_value)
     raise NotExportedError, "error : pin was already cleaned up" unless exported
     raise NotOutModeError, "error : mode isn't OUT" unless @mode == OUT
-    raise BadValueError, "error : bad pin value" unless PIN_VALUE.include?(new_value)
+    raise BadValueError, "error : bad pin value" unless PIN_VALUES.include?(new_value)
 
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'w') do |file|
       file.write(new_value)

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -15,12 +15,25 @@ class GPIO
   # Shortcut for high pin value (1)
   HIGH = 1
 
+  # Specifies all possible pin values
+  PIN_VALUES = [
+    LOW,
+    HIGH
+  ]
+
   # Shortcut for 'in' pin mode
   IN = 'in'
 
   # Shortcut for 'out' pin mode
   OUT = 'out'
 
+  # Specifies all possible pin modes
+  PIN_MODES = [
+    IN,
+    OUT
+  ]
+
+  # Base error for all other GPIO related errors
   class BaseError < StandardError
   end
 
@@ -62,7 +75,7 @@ class GPIO
   # @param mode [String] pin mode : IN or OUT
   # @raise [UnknownMode] if the mode isn't IN or OUT
   def mode=(new_mode)
-    raise UnknownModeError, "gpio error : unknown mode #{new_mode}" unless new_mode == IN or new_mode == OUT
+    raise UnknownModeError, "gpio error : unknown mode #{new_mode}" unless PIN_MODES.include?(new_mode)
 
     File.open("#{LIB_PATH}/gpio#{@pin}/direction", 'w') do |file|
       file.write(mode)
@@ -86,7 +99,7 @@ class GPIO
   # @raise [BadValue] if the provided value isn't LOW or HIGH
   def value=(new_value)
     raise NotOutModeError, "error : mode isn't OUT" unless @mode == OUT
-    raise BadValueError, "error : bad pin value" unless new_value.between? 0,1
+    raise BadValueError, "error : bad pin value" unless PIN_VALUE.include?(new_value)
 
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'w') do |file|
       file.write(new_value)

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -74,21 +74,22 @@ class GPIO
   # Read the value of the pin
   #
   # @return [Integer] pin's value : 0 or 1
-  def get_value
+  def value
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'r').read
   end
 
   # Set a value to the pin
   #   This method can only be used when the pin is in OUT mode
   #
-  # @param v [Integer] the value : LOW or HIGH
+  # @param new_value [Integer] the value : LOW or HIGH
   # @raise [NotOutMode] if the pin isn't in OUT mode
   # @raise [BadValue] if the provided value isn't LOW or HIGH
-  def set_value(v)
+  def value=(new_value)
     raise NotOutModeError, "error : mode isn't OUT" unless @mode == OUT
-    raise BadValueError, "error : bad pin value" unless v.between? 0,1
+    raise BadValueError, "error : bad pin value" unless new_value.between? 0,1
+
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'w') do |file|
-      file.write(v)
+      file.write(new_value)
     end
   end
 end

--- a/lib/raspi-gpio.rb
+++ b/lib/raspi-gpio.rb
@@ -1,10 +1,15 @@
-# raspi-gpio - A simple and light interface to interact with GPIO pins of the Raspberry Pi.
-#   Guide and source code : https://github.com/exybore/raspi-gpio-rb
-#   Documentation : https://rubydoc.info/gems/raspi-gpio
+# A simple and light interface to interact with GPIO pins of the Raspberry Pi.
+#   Guide and source code : https://github.com/sergio1990/raspi-gpio-rb
 #
-# @author exybore
-
-# Main class, to manage GPIO pins
+# @author exybore, sergio1990
+#
+# @example Common usage
+#   pin = GPIO.new(12, GPIO::OUT)
+#   pin.value = GPIO::LOW
+#   pin.mode = GPIO::IN
+#   pin.value # => either LOW or HIGH
+#   pin.cleanup
+#
 class GPIO
   # GPIO core library path
   LIB_PATH = '/sys/class/gpio'
@@ -49,6 +54,11 @@ class GPIO
   class BadValueError < BaseError
   end
 
+  # Exception to handle cases when trying to work with the pin which was
+  # already cleaned up
+  class NotExportedError < BaseError
+  end
+
   attr_reader :mode
 
   # Initialize the GPIO pin
@@ -57,24 +67,21 @@ class GPIO
   # @param mode [String] pin mode : IN or OUT
   def initialize(pin, mode = OUT)
     @pin = pin
-    begin
-      File.open("#{LIB_PATH}/unexport", 'w') do |file|
-        file.write(@pin)
-      end
-    rescue Errno::EINVAL
-      # Do nothing - the pin is already unexported
-    end
-    File.open("#{LIB_PATH}/export", 'w') do |file|
-      file.write(@pin)
-    end
+
+    unexport_pin
+    export_pin
+
     @mode = mode
+    @exported = true
   end
 
   # Set the pin mode
   #
   # @param mode [String] pin mode : IN or OUT
-  # @raise [UnknownMode] if the mode isn't IN or OUT
+  # @raise [NotExportedError] if the pin was already cleaned up
+  # @raise [UnknownModeError] if the mode isn't IN or OUT
   def mode=(new_mode)
+    raise NotExportedError, "gpio error : pin was already cleaned up" unless exported
     raise UnknownModeError, "gpio error : unknown mode #{new_mode}" unless PIN_MODES.include?(new_mode)
 
     File.open("#{LIB_PATH}/gpio#{@pin}/direction", 'w') do |file|
@@ -95,14 +102,40 @@ class GPIO
   #   This method can only be used when the pin is in OUT mode
   #
   # @param new_value [Integer] the value : LOW or HIGH
-  # @raise [NotOutMode] if the pin isn't in OUT mode
-  # @raise [BadValue] if the provided value isn't LOW or HIGH
+  # @raise [NotExportedError] if the pin was already cleaned up
+  # @raise [NotOutModeError] if the pin isn't in OUT mode
+  # @raise [BadValueError] if the provided value isn't LOW or HIGH
   def value=(new_value)
+    raise NotExportedError, "error : pin was already cleaned up" unless exported
     raise NotOutModeError, "error : mode isn't OUT" unless @mode == OUT
     raise BadValueError, "error : bad pin value" unless PIN_VALUE.include?(new_value)
 
     File.open("#{LIB_PATH}/gpio#{@pin}/value", 'w') do |file|
       file.write(new_value)
+    end
+  end
+
+  # Cleans up the pin by unexporting it
+  def cleanup
+    unexport_pin
+    @exported = false
+  end
+
+  private
+
+  attr_reader :exported
+
+  def unexport_pin
+    File.open("#{LIB_PATH}/unexport", 'w') do |file|
+      file.write(@pin)
+    end
+  rescue Errno::EINVAL
+    # Do nothing - the pin is already unexported
+  end
+
+  def export_pin
+    File.open("#{LIB_PATH}/export", 'w') do |file|
+      file.write(@pin)
     end
   end
 end

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -1,0 +1,159 @@
+module BoolToInteger
+  refine TrueClass do
+    def to_i
+      1
+    end
+  end
+
+  refine FalseClass do
+    def to_i
+      0
+    end
+  end
+end
+
+class RaspiPWM
+  using BoolToInteger
+
+  LIB_PATH = '/sys/class/pwm'
+
+  DUTY_CYCLE_RANGE = (0..100).freeze
+
+  # A frequency of a generated PWM signal
+  attr_reader :frequency
+
+  # The amount of time a digital signal is in `active` state relative to the
+  # period of the signal. The value should be between 0..100
+  attr_reader :duty_cycle
+
+  # Indicates whether the PWM is enabled or not
+  attr_reader :enabled?
+
+  # Base error for all other PWM related errors
+  class BaseError < StandardError
+  end
+
+  # Exception when trying to initialize with an unknown PWM channel
+  class UnknownChannelError < BaseError
+  end
+
+  # Exception to handle cases when trying to work with the PWM channel which was
+  # already cleaned up
+  class NotExportedError < BaseError
+  end
+
+  # Exception indicates that an invalid value was passed whether in a method or
+  # a property setter
+  class InvalidArgumentError < BaseError
+  end
+
+  # Initializes a PWM channel
+  #
+  # @param channel [Integer] a number of a channel
+  # @raise [UnknownChannelError] if trying to initialize with the wrong channel number
+  def init(channel:)
+    @channel = channel.to_i
+
+    verify_channel!
+
+    @frequency = 2
+    @duty_cycle = 50
+    calculate_ns
+
+    unexport_channel
+    export_channel
+  end
+
+  # Sets a new frequency value
+  #
+  # @param new_frequency [Integer] a new frequency value
+  # @raise [NotExportedError] if the channel was already cleaned up
+  def frequency=(new_frequency)
+    raise NotExportedError, "the channel was already unexported" unless exported
+
+    @frequency = new_frequency
+    calculate_ns
+
+    File.open("#{LIB_PATH}/pwmchip0/pwm#{channel}/period", 'w') do |file|
+      file.write(period_ns)
+    end
+  end
+
+  # Sets a new duty cycle
+  #
+  # @param duty_cycle [Integer] a new duty cycle value
+  # @raise [NotExportedError] if the channel was already cleaned up
+  # @raise [InvalidArgumentError] if an invalid value was set
+  def duty_cycle=(new_duty_cycle)
+    raise NotExportedError, "the channel was already unexported" unless exported
+    raise InvalidArgumentError, "the duty cycle value has to be between 0 and 100" unless DUTY_CYCLE_RANGE.include?(new_duty_cycle)
+
+    @duty_cycle = new_duty_cycle
+    calculate_ns
+
+    File.open("#{LIB_PATH}/pwmchip0/pwm#{channel}/duty_cycle", 'w') do |file|
+      file.write(duty_cycle_ns)
+    end
+  end
+
+  # Sets an enableness status of a PWM channel
+  #
+  # @param value [Boolean] whether true or false meaning enable or disable a channel
+  # @raise [NotExportedError] if the channel was already cleaned up
+  def enabled=(value)
+    raise NotExportedError, "the channel was already unexported" unless exported
+
+    @enabled = value
+
+    File.open("#{LIB_PATH}/pwmchip0/pwm#{channel}/enable", 'w') do |file|
+      file.write(@enabled.to_i)
+    end
+  end
+
+  # Cleans up the channel after completing using it
+  def cleanup
+    return unless exported
+
+    unexport_channel
+  end
+
+  private
+
+  attr_reader :channel, :exported, :period_ns, :duty_cycle_ns
+
+  def calculate_ns
+    period_sec = 1 / frequency.to_f
+    @period_ns = (period_sec * 10^9).round
+    @duty_cycle_ns = (@period_ns * (duty_cycle / 100)).round
+  end
+
+  def verify_channel!
+    pwm_channels = available_pwm_channels
+
+    return if pwm_channels.include?(channel)
+
+    raise UnknownChannelError, "Unknown PWM channel detected: `#{channel}`! Only #{pwm_channels} are available!"
+  end
+
+  def available_pwm_channels
+    npwm = File.open("#{LIB_PATH}/pwmchip0/npwm", 'r').read.to_i
+    (0..npwm - 1).to_a
+  end
+
+  def unexport_channel
+    File.open("#{LIB_PATH}/pwmchip0/unexport", 'w') do |file|
+      file.write(channel)
+    end
+  rescue Errno::EINVAL
+    # Do nothing - the channel is already unexported
+  ensure
+    @exported = false
+  end
+
+  def export_channel
+    File.open("#{LIB_PATH}/pwmchip0/export", 'w') do |file|
+      file.write(channel)
+    end
+    @exported = true
+  end
+end

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -82,6 +82,7 @@ class RaspiPWM
 
     unexport_channel
     export_channel
+    write_pwm_parameters
   end
 
   # Sets a new frequency value
@@ -93,10 +94,7 @@ class RaspiPWM
 
     @frequency = new_frequency
     calculate_ns
-
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/period", 'w') do |file|
-      file.write(period_ns)
-    end
+    write_pwm_parameters
   end
 
   # Sets a new duty cycle
@@ -110,10 +108,7 @@ class RaspiPWM
 
     @duty_cycle = new_duty_cycle
     calculate_ns
-
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/duty_cycle", 'w') do |file|
-      file.write(duty_cycle_ns)
-    end
+    write_pwm_parameters
   end
 
   # Sets an enableness status of a PWM channel
@@ -145,6 +140,16 @@ class RaspiPWM
     period_sec = 1 / frequency.to_f
     @period_ns = (period_sec * 10**9).round
     @duty_cycle_ns = (@period_ns * (duty_cycle / 100)).round
+  end
+
+  def write_pwm_parameters
+    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/period", 'w') do |file|
+      file.write(period_ns)
+    end
+
+    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/duty_cycle", 'w') do |file|
+      file.write(duty_cycle_ns)
+    end
   end
 
   def verify_chip!

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -39,7 +39,7 @@ class RaspiPWM
   attr_reader :duty_cycle
 
   # Indicates whether the PWM is enabled or not
-  attr_reader :enabled?
+  attr_reader :enabled
 
   # Base error for all other PWM related errors
   class BaseError < StandardError
@@ -69,7 +69,7 @@ class RaspiPWM
   # @param channel [Integer] a number of a channel
   # @raise [UnknownChipError] if trying to initialize with the wrong chip number
   # @raise [UnknownChannelError] if trying to initialize with the wrong channel number
-  def init(chip: 0, channel:)
+  def initialize(chip: 0, channel:)
     @chip = chip
     @channel = channel.to_i
 
@@ -143,7 +143,7 @@ class RaspiPWM
 
   def calculate_ns
     period_sec = 1 / frequency.to_f
-    @period_ns = (period_sec * 10^9).round
+    @period_ns = (period_sec * 10**9).round
     @duty_cycle_ns = (@period_ns * (duty_cycle / 100)).round
   end
 
@@ -170,7 +170,7 @@ class RaspiPWM
     File.open("#{LIB_PATH}/pwmchip#{chip}/unexport", 'w') do |file|
       file.write(channel)
     end
-  rescue Errno::EINVAL
+  rescue Errno::ENODEV
     # Do nothing - the channel is already unexported
   ensure
     @exported = false

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -82,7 +82,6 @@ class RaspiPWM
 
     unexport_channel
     export_channel
-    write_pwm_parameters
   end
 
   # Sets a new frequency value

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -82,6 +82,8 @@ class RaspiPWM
 
     unexport_channel
     export_channel
+
+    @enabled = false
   end
 
   # Sets a new frequency value
@@ -128,6 +130,7 @@ class RaspiPWM
   def cleanup
     return unless exported
 
+    enabled = false
     unexport_channel
   end
 

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -73,6 +73,9 @@ class RaspiPWM
     @chip = chip
     @channel = channel.to_i
 
+    @chip_path = "#{LIB_PATH}/pwmchip#{chip}"
+    @channel_path = "#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}"
+
     verify_chip!
     verify_channel!
 
@@ -121,7 +124,7 @@ class RaspiPWM
 
     @enabled = value
 
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/enable", 'w') do |file|
+    File.open("#{channel_path}/enable", 'w') do |file|
       file.write(@enabled.to_i)
     end
   end
@@ -137,6 +140,7 @@ class RaspiPWM
   private
 
   attr_reader :chip, :channel, :exported, :period_ns, :duty_cycle_ns
+  attr_reader :chip_path, :channel_path
 
   def calculate_ns
     period_sec = 1 / frequency.to_f
@@ -162,15 +166,15 @@ class RaspiPWM
     was_enabled_before = enabled
     enabled = false if was_enabled_before
 
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/duty_cycle", 'w') do |file|
+    File.open("#{channel_path}/duty_cycle", 'w') do |file|
       file.write(0)
     end
 
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/period", 'w') do |file|
+    File.open("#{channel_path}/period", 'w') do |file|
       file.write(period_ns)
     end
 
-    File.open("#{LIB_PATH}/pwmchip#{chip}/pwm#{channel}/duty_cycle", 'w') do |file|
+    File.open("#{channel_path}/duty_cycle", 'w') do |file|
       file.write(duty_cycle_ns)
     end
 
@@ -178,7 +182,7 @@ class RaspiPWM
   end
 
   def verify_chip!
-    return if Dir.exist?("#{LIB_PATH}/pwmchip#{chip}")
+    return if Dir.exist?(chip_path)
 
     raise UnknownChipError, "Unknown PWM chip detected: `#{chip}`!"
   end
@@ -192,12 +196,12 @@ class RaspiPWM
   end
 
   def available_pwm_channels
-    npwm = File.open("#{LIB_PATH}/pwmchip#{chip}/npwm", 'r').read.to_i
+    npwm = File.open("#{chip_path}/npwm", 'r').read.to_i
     (0..npwm - 1).to_a
   end
 
   def unexport_channel
-    File.open("#{LIB_PATH}/pwmchip#{chip}/unexport", 'w') do |file|
+    File.open("#{chip_path}/unexport", 'w') do |file|
       file.write(channel)
     end
   rescue Errno::ENODEV
@@ -207,7 +211,7 @@ class RaspiPWM
   end
 
   def export_channel
-    File.open("#{LIB_PATH}/pwmchip#{chip}/export", 'w') do |file|
+    File.open("#{chip_path}/export", 'w') do |file|
       file.write(channel)
     end
     @exported = true

--- a/lib/raspi-pwm.rb
+++ b/lib/raspi-pwm.rb
@@ -138,7 +138,7 @@ class RaspiPWM
   def calculate_ns
     period_sec = 1 / frequency.to_f
     @period_ns = (period_sec * 10**9).round
-    @duty_cycle_ns = (@period_ns * (duty_cycle / 100)).round
+    @duty_cycle_ns = (@period_ns * (duty_cycle / 100.0)).round
   end
 
   def write_pwm_parameters

--- a/raspi-gpio.gemspec
+++ b/raspi-gpio.gemspec
@@ -1,12 +1,12 @@
 Gem::Specification.new do |s|
   s.name        = 'raspi-gpio'
-  s.version     = '1.0.1'
+  s.version     = '2.0.0'
   s.license     = 'MIT'
   s.summary     = "🔌 Simple & light Raspberry Pi GPIO interface."
   s.description = "A simple and light interface to interact with GPIO pins of the Raspberry Pi."
-  s.authors     = ["Exybore"]
-  s.email       = 'exybore@gmail.com'
+  s.authors     = ["Sergey Gernyak", "Exybore"]
+  s.email       = 'sergeg1990@gmail.com'
   s.files       = ["lib/raspi-gpio.rb"]
-  s.homepage    = 'https://github.com/exybore/raspi-gpio-rb'
-  s.metadata    = { "source_code_uri" => "https://github.com/exybore/raspi-gpio-rb" }
+  s.homepage    = 'https://github.com/sergio1990/raspi-gpio-rb'
+  s.metadata    = { "source_code_uri" => "https://github.com/sergio1990/raspi-gpio-rb" }
 end

--- a/raspi-gpio.gemspec
+++ b/raspi-gpio.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'raspi-gpio'
-  s.version     = '2.0.0'
+  s.version     = '2.0.1'
   s.license     = 'MIT'
   s.summary     = "🔌 Simple & light Raspberry Pi GPIO interface."
   s.description = "A simple and light interface to interact with GPIO pins of the Raspberry Pi."

--- a/raspi-gpio.gemspec
+++ b/raspi-gpio.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "A simple and light interface to interact with GPIO pins of the Raspberry Pi."
   s.authors     = ["Sergey Gernyak", "Exybore"]
   s.email       = 'sergeg1990@gmail.com'
-  s.files       = ["lib/raspi-gpio.rb"]
+  s.files       = ["lib/raspi-gpio.rb", "lib/raspi-pwm.rb"]
   s.homepage    = 'https://github.com/sergio1990/raspi-gpio-rb'
   s.metadata    = { "source_code_uri" => "https://github.com/sergio1990/raspi-gpio-rb" }
 end

--- a/raspi-gpio.gemspec
+++ b/raspi-gpio.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'raspi-gpio'
-  s.version     = '2.0.1'
+  s.version     = '2.1.0'
   s.license     = 'MIT'
   s.summary     = "🔌 Simple & light Raspberry Pi GPIO interface."
   s.description = "A simple and light interface to interact with GPIO pins of the Raspberry Pi."


### PR DESCRIPTION
I kept getting `Errno::EPERM (Operation not permitted @ fptr_finalize_flush - /sys/class/gpio/gpio4/value)` when attempting to set the value of a GPIO pin.  The output of `gpio readall` revealed that the output was still set as "IN", even though I was initializing the pin as `OUT`.

I found that if I add `pin.mode = OUT` before `pin.value = `, it worked.

Looking at the source, it seemed that the initializer was only setting the mode in an instance variable and never actually calling the setter.  I changed the initializer to call the setter, and now GPIO pins have the correct mode when initialized.